### PR TITLE
Bump actions-runner version to v2.283.1

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,8 +16,8 @@ systemctl enable containerd.service
 cd /home/ubuntu
 mkdir actions-runner && cd actions-runner
 # See https://github.com/actions/runner/releases
-curl -fsSLo actions-runner.tar.gz https://github.com/actions/runner/releases/download/v2.281.1/actions-runner-linux-arm64-2.281.1.tar.gz
-echo "f424d953a4df285839e8bd73474c3f92307a5605e6d473313a130b30550d55bd actions-runner.tar.gz" | sha256sum -c
+curl -fsSLo actions-runner.tar.gz https://github.com/actions/runner/releases/download/v2.283.1/actions-runner-linux-arm64-2.283.1.tar.gz
+echo "20c3d1e6ff03b0c5bc73c4ef7710e0048f509b19d5b789e26f468feafddb8eda actions-runner.tar.gz" | sha256sum -c
 tar xzf actions-runner.tar.gz
 rm -f actions-runner.tar.gz
 ./bin/installdependencies.sh


### PR DESCRIPTION
Supports the `--ephemeral` flag